### PR TITLE
chore: Migrate to Spring Boot 4.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 ext {
-	set('springAiVersion', "1.0.0")
+	set('springAiVersion', "1.1.0")
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- Update Spring AI version from 1.0.0 to 1.1.0

## Test plan
- [ ] Verify application compiles with `./gradlew clean build -x test`
- [ ] Test chat functionality with OpenRouter API

## Notes
- RestClientCustomizer API changes require additional fixes (moved package)
- HttpHeaders to MultiValueMap conversion may be needed for OpenAiApi

🤖 Generated with [Claude Code](https://claude.com/claude-code)