### PR TITLE
chore: Migrate to Spring Boot 4.0.1 and Spring AI 2.0.0-M1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'java'
 	id 'org.cyclonedx.bom' version '3.1.0'
 	id 'com.gorylenko.gradle-git-properties' version '2.5.4'
-	id 'org.springframework.boot' version '4.0.0'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'org.springdoc.openapi-gradle-plugin' version '1.9.0'
 }
@@ -11,17 +11,19 @@ group = 'me.pacphi'
 
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 repositories {
 	mavenCentral()
+	maven {
+		url = uri("https://repo.spring.io/milestone")
+	}
 }
 
 ext {
-	set('springAiVersion', "1.0.0")
+	set('springAiVersion', "2.0.0-M1")
 }
 
 dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,6 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven { url 'https://repo.spring.io/milestone' }
-        maven { url 'https://repo.spring.io/snapshot' }
     }
 }
 

--- a/src/main/java/me/pacphi/config/Http.java
+++ b/src/main/java/me/pacphi/config/Http.java
@@ -1,10 +1,10 @@
 package me.pacphi.config;
 
-import org.springframework.boot.web.client.RestClientCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
 
 import java.time.Duration;
 
@@ -12,13 +12,13 @@ import java.time.Duration;
 public class Http {
 
     @Bean
-    public RestClientCustomizer restClientCustomizer() {
-        return restClientBuilder -> {
-            SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-            factory.setConnectTimeout((int) Duration.ofMinutes(10).toMillis());
-            factory.setReadTimeout((int) Duration.ofMinutes(10).toMillis());
-            restClientBuilder.defaultHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, deflate");
-            restClientBuilder.requestFactory(factory);
-        };
+    public RestClient.Builder restClientBuilder() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofMinutes(10));
+        factory.setReadTimeout(Duration.ofMinutes(10));
+
+        return RestClient.builder()
+                .requestFactory(factory)
+                .defaultHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, deflate");
     }
 }

--- a/src/main/java/me/pacphi/config/MultiChat.java
+++ b/src/main/java/me/pacphi/config/MultiChat.java
@@ -15,7 +15,7 @@ import org.springframework.ai.retry.RetryUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
-import org.springframework.retry.support.RetryTemplate;
+import org.springframework.core.retry.RetryTemplate;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.reactive.function.client.WebClient;
 


### PR DESCRIPTION
## Summary

This PR migrates the project to Spring Boot 4.0.1 and Spring AI 2.0.0-M1, addressing breaking changes in Spring Boot 4.x APIs.

## Changes

### Build Configuration Updates
- **Spring Boot:** 4.0.0 → 4.0.1
- **Spring AI:** 1.0.0 → 2.0.0-M1
- Added Spring milestone repository for Spring AI 2.0.0-M1 artifacts
- Changed Java toolchain configuration to sourceCompatibility/targetCompatibility

### Code Migration Changes

#### Http.java - RestClient Configuration
Simplified RestClient.Builder configuration for Spring Boot 4.x compatibility:
```java
// Updated from RestClientCustomizer to direct RestClient.Builder bean
@Bean
public RestClient.Builder restClientBuilder() {
    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
    factory.setConnectTimeout(Duration.ofMinutes(10));
    factory.setReadTimeout(Duration.ofMinutes(10));
    
    return RestClient.builder()
            .requestFactory(factory)
            .defaultHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, deflate");
}
```

#### MultiChat.java - RetryTemplate Import
Changed RetryTemplate import path (Spring AI 2.0 relocation):
```java
// Before
import org.springframework.retry.support.RetryTemplate;

// After  
import org.springframework.core.retry.RetryTemplate;
```

### Settings Updates
- Removed snapshot repository from settings.gradle (using milestone only for Spring AI 2.0.0-M1)

## Validation

- ✅ Build: PASSED (`./gradlew clean build`)
- ✅ All compilation issues resolved
- ✅ No test failures (no tests in source)

## Test Plan

- [ ] Run full build verification
- [ ] Test OpenRouter API integration
- [ ] Verify multi-model chat functionality
- [ ] Test HTTP client timeout configuration
- [ ] Validate actuator endpoints

## Files Modified

- `build.gradle` - Version updates
- `settings.gradle` - Repository configuration  
- `src/main/java/me/pacphi/config/Http.java` - RestClient configuration
- `src/main/java/me/pacphi/config/MultiChat.java` - RetryTemplate import

🤖 Generated with [Claude Code](https://claude.com/claude-code)